### PR TITLE
Work with version ~2.9 of rubycritic

### DIFF
--- a/guard-rubycritic.gemspec
+++ b/guard-rubycritic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_path  = "lib"
 
   spec.add_runtime_dependency "guard", "~> 2.6"
-  spec.add_runtime_dependency "rubycritic", "~> 1.4"
+  spec.add_runtime_dependency "rubycritic", "~> 2.9"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/guard/rubycritic.rb
+++ b/lib/guard/rubycritic.rb
@@ -12,7 +12,7 @@ module Guard
     # @return [Object] the task result
     #
     def start
-      @rubycritic = ::Rubycritic.create
+      @rubycritic = ::Rubycritic::CommandFactory.create
       @rubycritic.extend(AdditionalMethodsForGuard)
       UI.info "Guard::Rubycritic is critiquing"
     end


### PR DESCRIPTION
Get the gaurd-rubycritic gem working with what is currently the latest version of rubycritic.