### PR TITLE
README: Repair Markdown link rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Guard::RubyCritic
 [![Code Climate](http://img.shields.io/codeclimate/github/whitesmith/guard-rubycritic.svg)](https://codeclimate.com/github/whitesmith/guard-rubycritic)
 
 <img src="http://i.imgur.com/66HACCD.png" alt="RubyCritic Icon" align="right" />
+
 Guard::RubyCritic is a tool that uses [RubyCritic](https://github.com/whitesmith/rubycritic) to detect and report smells in Ruby code in real-time.
 
 Installation


### PR DESCRIPTION
This PR repairs badly-rendered Markdown by adding a whitespace after the HTML `<img>` tag.

I guess this made the Markdown not be a "literal" but a parseable Markdown again.